### PR TITLE
Add inventory IO history support

### DIFF
--- a/src/main/java/com/cmms4/inventoryMaster/controller/InventoryIoController.java
+++ b/src/main/java/com/cmms4/inventoryMaster/controller/InventoryIoController.java
@@ -35,13 +35,20 @@ public class InventoryIoController {
     @PostMapping("/save")
     public String saveInventoryIo(@RequestBody List<InventoryHistory> ioList, HttpSession session) {
         String companyId = (String) session.getAttribute("companyId");
+        String username = (String) session.getAttribute("username");
 
         try {
-            ioList.forEach(io -> io.setCompanyId(companyId)); // companyId 서버에서 세팅
-            inventoryMasterService.processInventoryIo(ioList);
+            ioList.forEach(io -> io.setCompanyId(companyId));
+            inventoryMasterService.processInventoryIo(ioList, username);
             return "success";
         } catch (Exception e) {
             return "error: " + e.getMessage();
         }
+    }
+
+    @GetMapping("/history/{inventoryId}")
+    public List<InventoryHistory> getHistory(@PathVariable String inventoryId, HttpSession session) {
+        String companyId = (String) session.getAttribute("companyId");
+        return inventoryMasterService.getInventoryHistory(companyId, inventoryId);
     }
 }

--- a/src/main/java/com/cmms4/inventoryMaster/controller/InventoryMasterController.java
+++ b/src/main/java/com/cmms4/inventoryMaster/controller/InventoryMasterController.java
@@ -75,6 +75,15 @@ public class InventoryMasterController {
         return "inventoryMaster/inventoryMasterForm";
     }
 
+    @GetMapping("/inventoryIoHistory")
+    public String ioHistory(Model model, HttpSession session) {
+        String companyId = (String) session.getAttribute("companyId");
+        String siteId = (String) session.getAttribute("siteId");
+        model.addAttribute("companyId", companyId);
+        model.addAttribute("siteId", siteId);
+        return "inventoryMaster/inventoryIoHistory";
+    }
+
     /**
      * 재고 마스터 저장
      * @param inventoryMaster 재고 마스터 정보

--- a/src/main/java/com/cmms4/inventoryMaster/repository/InventoryHistoryRepository.java
+++ b/src/main/java/com/cmms4/inventoryMaster/repository/InventoryHistoryRepository.java
@@ -3,7 +3,16 @@ package com.cmms4.inventoryMaster.repository;
 import com.cmms4.inventoryMaster.entity.InventoryHistory;
 import com.cmms4.inventoryMaster.entity.InventoryHistoryId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface InventoryHistoryRepository extends JpaRepository<InventoryHistory, InventoryHistoryId> {
-    
+
+    @Query("SELECT MAX(h.historyId) FROM InventoryHistory h WHERE h.companyId = :companyId")
+    String findMaxHistoryIdByCompanyId(@Param("companyId") String companyId);
+
+    List<InventoryHistory> findByCompanyIdAndInventoryIdOrderByIoDateDesc(String companyId, String inventoryId);
+
 }

--- a/src/main/resources/templates/inventoryMaster/inventoryIoHistory.html
+++ b/src/main/resources/templates/inventoryMaster/inventoryIoHistory.html
@@ -68,11 +68,20 @@
     });
 
     document.getElementById('saveBtn').addEventListener('click', () => {
-        const data = hot.getData().filter(row => row[2]); // Inventory ID 필수
+        const rows = hot.getData().filter(r => r[2]);
+        const payload = rows.map(r => ({
+            ioDate: r[0],
+            ioType: r[1],
+            inventoryId: r[2],
+            qty: r[4],
+            unitPrice: r[5],
+            totalValue: r[6],
+            note: r[7]
+        }));
         fetch('/inventoryIo/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data)
+            body: JSON.stringify(payload)
         })
         .then(res => res.ok ? location.reload() : alert('Error saving data'))
         .catch(err => alert('Error: ' + err));

--- a/src/main/resources/templates/inventoryMaster/inventoryMasterList.html
+++ b/src/main/resources/templates/inventoryMaster/inventoryMasterList.html
@@ -23,10 +23,14 @@
             <span th:text="${errorMessage}"></span>
         </div>
 
-        <div class="mb-4">
+        <div class="mb-4 flex gap-3">
             <a th:href="@{/inventoryMaster/inventoryMasterForm(companyId=${companyId}, siteId=${siteId})}"
                class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
                 Add New Inventory
+            </a>
+            <a th:href="@{/inventoryMaster/inventoryIoHistory(companyId=${companyId}, siteId=${siteId})}"
+               class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                Inventory I/O
             </a>
         </div>
 

--- a/src/main/resources/templates/layout/defaultLayout.html
+++ b/src/main/resources/templates/layout/defaultLayout.html
@@ -110,6 +110,7 @@
           <ul class="submenu hidden pl-7 mt-1 space-y-1">
             <li><a th:href="@{/inventoryMaster/inventoryMasterForm}" class="block py-1 hover:text-yellow-300">입력</a></li>
             <li><a th:href="@{/inventoryMaster/inventoryMasterList}" class="block py-1 hover:text-yellow-300">목록</a></li>
+            <li><a th:href="@{/inventoryMaster/inventoryIoHistory}" class="block py-1 hover:text-yellow-300">입출고</a></li>
           </ul>
         </li>
 


### PR DESCRIPTION
## Summary
- implement inventory history repository queries
- update service to process inventory IO with pessimistic lock and history ID
- expose history API and IO save in controller
- add IO history page route and menu
- enable inventory I/O button on list page
- update Handsontable script to send structured JSON

## Testing
- `sh gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c87879c8c8323bb81177fe157d967